### PR TITLE
PISTON-1112: fix validation of agent pause timeout/time-limit

### DIFF
--- a/include/acdc_config.hrl
+++ b/include/acdc_config.hrl
@@ -2,6 +2,10 @@
 
 -include_lib("kazoo_stdlib/include/kz_types.hrl").
 
+-define(ACDC_CONFIG_CAT, <<"acdc">>).
+
+-define(DEFAULT_AGENT_PAUSE_TIMEOUT, kapps_config:get(?ACDC_CONFIG_CAT, <<"default_agent_pause_timeout">>, 600)).
+
 %% Save data to the DB
 -define(ACDC_ARCHIVE_WINDOW,
         kapps_config:get_integer(<<"acdc">>, <<"archive_window_s">>, ?SECONDS_IN_HOUR)).

--- a/src/acdc_agent_handler.erl
+++ b/src/acdc_agent_handler.erl
@@ -29,8 +29,6 @@
 -include("acdc.hrl").
 -include_lib("kazoo_amqp/include/kapi_conf.hrl").
 
--define(DEFAULT_PAUSE, kapps_config:get(?CONFIG_CAT, <<"default_agent_pause_timeout">>, 600)).
-
 -spec handle_status_update(kz_json:object(), kz_term:proplist()) -> 'ok'.
 handle_status_update(JObj, _Props) ->
     _ = kz_log:put_callid(JObj),
@@ -48,7 +46,7 @@ handle_status_update(JObj, _Props) ->
             maybe_stop_agent(AccountId, AgentId, JObj);
         <<"pause">> ->
             'true' = kapi_acdc_agent:pause_v(JObj),
-            Timeout = kz_json:get_value(<<"Time-Limit">>, JObj, ?DEFAULT_PAUSE),
+            Timeout = kz_json:get_value(<<"Time-Limit">>, JObj, ?DEFAULT_AGENT_PAUSE_TIMEOUT),
             maybe_pause_agent(AccountId, AgentId, Timeout, JObj);
         <<"resume">> ->
             'true' = kapi_acdc_agent:resume_v(JObj),

--- a/src/acdc_maintenance.erl
+++ b/src/acdc_maintenance.erl
@@ -479,16 +479,15 @@ agent_logout(AcctId, AgentId) ->
 
 -spec agent_pause(kz_term:ne_binary(), kz_term:ne_binary()) -> 'ok'.
 agent_pause(AcctId, AgentId) ->
-    Timeout = kapps_config:get_integer(?CONFIG_CAT, <<"default_agent_pause_timeout">>, 600),
-    agent_pause(AcctId, AgentId, Timeout).
+    agent_pause(AcctId, AgentId, ?DEFAULT_AGENT_PAUSE_TIMEOUT).
 
--spec agent_pause(kz_term:ne_binary(), kz_term:ne_binary(), pos_integer()) -> 'ok'.
+-spec agent_pause(kz_term:ne_binary(), kz_term:ne_binary(), pos_integer() | kz_term:ne_binary()) -> 'ok'.
 agent_pause(AcctId, AgentId, Timeout) ->
     kz_log:put_callid(?MODULE),
     Update = props:filter_undefined(
                [{<<"Account-ID">>, AcctId}
                ,{<<"Agent-ID">>, AgentId}
-               ,{<<"Timeout">>, kz_term:to_integer(Timeout)}
+               ,{<<"Time-Limit">>, Timeout}
                 | kz_api:default_headers(?APP_NAME, ?APP_VERSION)
                ]),
     _ = kz_amqp_worker:cast(Update, fun kapi_acdc_agent:publish_pause/1),

--- a/src/cf_acdc_agent.erl
+++ b/src/cf_acdc_agent.erl
@@ -29,6 +29,7 @@
         ,logout_agent/2
         ]).
 
+-include("acdc_config.hrl").
 -include_lib("callflow/src/callflow.hrl").
 
 %%------------------------------------------------------------------------------
@@ -159,10 +160,7 @@ pause_agent(Call, AgentId, Data, Timeout) ->
     _ = play_agent_pause(Call),
     update_agent_status(Call, AgentId, Data, fun kapi_acdc_agent:publish_pause/1, Timeout).
 pause_agent(Call, AgentId, Data) ->
-    Timeout = kz_json:get_value(<<"timeout">>
-                               ,Data
-                               ,kapps_config:get(<<"acdc">>, <<"default_agent_pause_timeout">>, 600)
-                               ),
+    Timeout = kz_json:get_value(<<"timeout">>, Data, ?DEFAULT_AGENT_PAUSE_TIMEOUT),
     lager:info("agent ~s is pausing work for ~b s", [AgentId, Timeout]),
     pause_agent(Call, AgentId, Data, Timeout).
 

--- a/src/kapi_acdc_agent.erl
+++ b/src/kapi_acdc_agent.erl
@@ -238,7 +238,7 @@ stats_resp_v(JObj) ->
                       ]).
 -define(AGENT_TYPES, []).
 
--define(PAUSE_HEADERS, [<<"Time-Limit">> | ?AGENT_HEADERS]).
+-define(OPTIONAL_PAUSE_HEADERS, [<<"Time-Limit">> | ?OPTIONAL_AGENT_HEADERS]).
 
 -define(LOGIN_VALUES, [{<<"Event-Name">>, <<"login">>} | ?AGENT_VALUES]).
 -define(LOGOUT_VALUES, [{<<"Event-Name">>, <<"logout">>} | ?AGENT_VALUES]).
@@ -331,7 +331,7 @@ logout_queue_v(JObj) ->
           {'error', string()}.
 pause(Props) when is_list(Props) ->
     case pause_v(Props) of
-        'true' -> kz_api:build_message(Props, ?PAUSE_HEADERS, ?OPTIONAL_AGENT_HEADERS);
+        'true' -> kz_api:build_message(Props, ?AGENT_HEADERS, ?OPTIONAL_PAUSE_HEADERS);
         'false' -> {'error', "Proplist failed validation for agent_pause"}
     end;
 pause(JObj) ->
@@ -339,7 +339,7 @@ pause(JObj) ->
 
 -spec pause_v(kz_term:api_terms()) -> boolean().
 pause_v(Prop) when is_list(Prop) ->
-    kz_api:validate(Prop, ?PAUSE_HEADERS, ?PAUSE_VALUES, ?PAUSE_TYPES);
+    kz_api:validate(Prop, ?AGENT_HEADERS, ?PAUSE_VALUES, ?PAUSE_TYPES);
 pause_v(JObj) ->
     pause_v(kz_json:to_proplist(JObj)).
 

--- a/src/kapi_acdc_agent.erl
+++ b/src/kapi_acdc_agent.erl
@@ -232,12 +232,13 @@ stats_resp_v(JObj) ->
 -define(OPTIONAL_AGENT_HEADERS, [<<"Presence-ID">>
                                 ,<<"Presence-State">>
                                 ,<<"Queue-ID">>
-                                ,<<"Time-Limit">>
                                 ]).
 -define(AGENT_VALUES, [{<<"Event-Category">>, <<"agent">>}
                       ,{<<"Presence-State">>, kapi_presence:presence_states()}
                       ]).
 -define(AGENT_TYPES, []).
+
+-define(PAUSE_HEADERS, [<<"Time-Limit">> | ?AGENT_HEADERS]).
 
 -define(LOGIN_VALUES, [{<<"Event-Name">>, <<"login">>} | ?AGENT_VALUES]).
 -define(LOGOUT_VALUES, [{<<"Event-Name">>, <<"logout">>} | ?AGENT_VALUES]).
@@ -247,6 +248,14 @@ stats_resp_v(JObj) ->
 -define(LOGIN_QUEUE_VALUES, [{<<"Event-Name">>, <<"login_queue">>} | ?AGENT_VALUES]).
 -define(LOGOUT_QUEUE_VALUES, [{<<"Event-Name">>, <<"logout_queue">>} | ?AGENT_VALUES]).
 -define(RESTART_VALUES, [{<<"Event-Name">>, <<"restart">>} | ?AGENT_VALUES]).
+
+-define(PAUSE_TYPES, [{<<"Time-Limit">>, fun(<<"infinity">>) -> 'true';
+                                            (TimeLimit) when is_integer(TimeLimit) -> TimeLimit >= 0;
+                                            (_) -> 'false'
+                                         end
+                      }
+                      | ?AGENT_TYPES
+                     ]).
 
 -spec login(kz_term:api_terms()) ->
           {'ok', iolist()} |
@@ -322,7 +331,7 @@ logout_queue_v(JObj) ->
           {'error', string()}.
 pause(Props) when is_list(Props) ->
     case pause_v(Props) of
-        'true' -> kz_api:build_message(Props, ?AGENT_HEADERS, ?OPTIONAL_AGENT_HEADERS);
+        'true' -> kz_api:build_message(Props, ?PAUSE_HEADERS, ?OPTIONAL_AGENT_HEADERS);
         'false' -> {'error', "Proplist failed validation for agent_pause"}
     end;
 pause(JObj) ->
@@ -330,7 +339,7 @@ pause(JObj) ->
 
 -spec pause_v(kz_term:api_terms()) -> boolean().
 pause_v(Prop) when is_list(Prop) ->
-    kz_api:validate(Prop, ?AGENT_HEADERS, ?PAUSE_VALUES, ?AGENT_TYPES);
+    kz_api:validate(Prop, ?PAUSE_HEADERS, ?PAUSE_VALUES, ?PAUSE_TYPES);
 pause_v(JObj) ->
     pause_v(kz_json:to_proplist(JObj)).
 


### PR DESCRIPTION
acdc component of https://github.com/2600hz/kazoo-crossbar/pull/36

- schema validates system_config.acdc default_agent_pause_timeout for non-negative integers or the "infinity" special string
- refactored out ?DEFAULT_AGENT_PAUSE_TIMEOUT into shared header
- fixed acdc_maintenance expecting integer, despite possibility of <<"infinity">> value
- moved Time-Limit validation in kapi_acdc_agent into PAUSE_* macros rather than AGENT_*