### PR TITLE
PISTON-1185: remove unused ACDc `pending_logged_out` status

### DIFF
--- a/src/acdc_agent_stats.erl
+++ b/src/acdc_agent_stats.erl
@@ -15,7 +15,6 @@
 -export([agent_ready/2
         ,agent_logged_in/2
         ,agent_logged_out/2
-        ,agent_pending_logged_out/2
         ,agent_connecting/3, agent_connecting/6
         ,agent_connected/3, agent_connected/6
         ,agent_wrapup/3
@@ -94,21 +93,6 @@ agent_logged_out(AccountId, AgentId) ->
     log_status_change(AccountId, Prop),
     kz_amqp_worker:cast(Prop
                        ,fun kapi_acdc_stats:publish_status_logged_out/1
-                       ).
-
--spec agent_pending_logged_out(kz_term:ne_binary(), kz_term:ne_binary()) ->
-          'ok'.
-agent_pending_logged_out(AccountId, AgentId) ->
-    Prop = props:filter_undefined(
-             [{<<"Account-ID">>, AccountId}
-             ,{<<"Agent-ID">>, AgentId}
-             ,{<<"Timestamp">>, kz_time:now_s()}
-             ,{<<"Status">>, <<"pending_logged_out">>}
-              | kz_api:default_headers(?APP_NAME, ?APP_VERSION)
-             ]),
-    log_status_change(AccountId, Prop),
-    kz_amqp_worker:cast(Prop
-                       ,fun kapi_acdc_stats:publish_status_pending_logged_out/1
                        ).
 
 -spec agent_connecting(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary()) ->
@@ -210,7 +194,6 @@ handle_status_stat(JObj, Props) ->
                  <<"ready">> -> kapi_acdc_stats:status_ready_v(JObj);
                  <<"logged_in">> -> kapi_acdc_stats:status_logged_in_v(JObj);
                  <<"logged_out">> -> kapi_acdc_stats:status_logged_out_v(JObj);
-                 <<"pending_logged_out">> -> kapi_acdc_stats:status_pending_logged_out_v(JObj);
                  <<"connecting">> -> kapi_acdc_stats:status_connecting_v(JObj);
                  <<"connected">> -> kapi_acdc_stats:status_connected_v(JObj);
                  <<"wrapup">> -> kapi_acdc_stats:status_wrapup_v(JObj);

--- a/src/acdc_stats.erl
+++ b/src/acdc_stats.erl
@@ -162,7 +162,6 @@ call_table_opts() ->
                      ,[{<<"acdc_status_stat">>, <<"ready">>}
                       ,{<<"acdc_status_stat">>, <<"logged_in">>}
                       ,{<<"acdc_status_stat">>, <<"logged_out">>}
-                      ,{<<"acdc_status_stat">>, <<"pending_logged_out">>}
                       ,{<<"acdc_status_stat">>, <<"connecting">>}
                       ,{<<"acdc_status_stat">>, <<"connected">>}
                       ,{<<"acdc_status_stat">>, <<"wrapup">>}

--- a/src/kapi_acdc_stats.erl
+++ b/src/kapi_acdc_stats.erl
@@ -37,7 +37,6 @@
         ,status_ready/1, status_ready_v/1
         ,status_logged_in/1, status_logged_in_v/1
         ,status_logged_out/1, status_logged_out_v/1
-        ,status_pending_logged_out/1, status_pending_logged_out_v/1
         ,status_connecting/1, status_connecting_v/1
         ,status_connected/1, status_connected_v/1
         ,status_wrapup/1, status_wrapup_v/1
@@ -74,7 +73,6 @@
         ,publish_status_ready/1, publish_status_ready/2
         ,publish_status_logged_in/1, publish_status_logged_in/2
         ,publish_status_logged_out/1, publish_status_logged_out/2
-        ,publish_status_pending_logged_out/1, publish_status_pending_logged_out/2
         ,publish_status_connecting/1, publish_status_connecting/2
         ,publish_status_connected/1, publish_status_connected/2
         ,publish_status_wrapup/1, publish_status_wrapup/2
@@ -523,23 +521,6 @@ status_logged_out_v(Prop) when is_list(Prop) ->
 status_logged_out_v(JObj) ->
     status_logged_out_v(kz_json:to_proplist(JObj)).
 
--spec status_pending_logged_out(kz_term:api_terms()) ->
-          {'ok', iolist()} |
-          {'error', string()}.
-status_pending_logged_out(Props) when is_list(Props) ->
-    case status_pending_logged_out_v(Props) of
-        'true' -> kz_api:build_message(Props, ?STATUS_HEADERS, ?STATUS_OPTIONAL_HEADERS);
-        'false' -> {'error', "Proplist failed validation for status_logged_out"}
-    end;
-status_pending_logged_out(JObj) ->
-    status_pending_logged_out(kz_json:to_proplist(JObj)).
-
--spec status_pending_logged_out_v(kz_term:api_terms()) -> boolean().
-status_pending_logged_out_v(Prop) when is_list(Prop) ->
-    kz_api:validate(Prop, ?STATUS_HEADERS, ?STATUS_VALUES(<<"pending_logged_out">>), ?STATUS_TYPES);
-status_pending_logged_out_v(JObj) ->
-    status_pending_logged_out_v(kz_json:to_proplist(JObj)).
-
 -spec status_connecting(kz_term:api_terms()) ->
           {'ok', iolist()} |
           {'error', string()}.
@@ -777,15 +758,6 @@ publish_status_logged_out(JObj) ->
 -spec publish_status_logged_out(kz_term:api_terms(), binary()) -> 'ok'.
 publish_status_logged_out(API, ContentType) ->
     {'ok', Payload} = kz_api:prepare_api_payload(API, ?STATUS_VALUES(<<"logged_out">>), fun status_logged_out/1),
-    kz_amqp_util:kapps_publish(status_stat_routing_key(API), Payload, ContentType).
-
--spec publish_status_pending_logged_out(kz_term:api_terms()) -> 'ok'.
-publish_status_pending_logged_out(JObj) ->
-    publish_status_pending_logged_out(JObj, ?DEFAULT_CONTENT_TYPE).
-
--spec publish_status_pending_logged_out(kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
-publish_status_pending_logged_out(API, ContentType) ->
-    {'ok', Payload} = kz_api:prepare_api_payload(API, ?STATUS_VALUES(<<"pending_logged_out">>), fun status_pending_logged_out/1),
     kz_amqp_util:kapps_publish(status_stat_routing_key(API), Payload, ContentType).
 
 -spec publish_status_connecting(kz_term:api_terms()) -> 'ok'.


### PR DESCRIPTION
`kazoo-acdc` component of https://github.com/2600hz/kazoo-crossbar/pull/121