### PR TITLE
PISTON-973: big acdc_queue_manager refactor + queue manager diag tool

### DIFF
--- a/doc/troubleshooting.md
+++ b/doc/troubleshooting.md
@@ -1,1 +1,41 @@
 ### Troubleshooting
+
+#### Queue Manager Diagnostics
+
+The `acdc_queue_manager_diag` and `acdc_queue_manager_diag_sup` modules provide a real-time play-by-play of strategy state changes for a queue manager. This tool enables more reliable diagnosis of issues related to unexpected strategy states (e.g. agents in incorrect ringing/busy/available/unavailable states).
+
+To start diagnostics for a queue, open a remote shell to the Kazoo node using `kazoo-applications connect`. On the remote shell, run
+
+```
+acdc_maintenance:start_queue_diagnostics(AccountId, QueueId).
+```
+
+replacing `AccountId` and `QueueId` with the binary representations of those values. For example: `acdc_maintenance:start_queue_diagnostics(<<"3d24e4ba001a096df9d925e1c2dda09b">>, <<"854ebe1f6871cff2e292cfcab6bfbff6">>).`
+
+You will see output like:
+
+```
+|  Timestamp  | Message                                                        |
+|-------------|----------------------------------------------------------------|
+This diagnostic process is expensive. Remember to stop diagnostics when you are done!
+To stop: `acdc_maintenance:stop_queue_diagnostics(list_to_pid("<0.15215.0>")).`
+ok
+```
+
+As mentioned in the output, you can run `acdc_maintenance:stop_queue_diagnostics` to stop the diagnostics stream at any point. The PID in the output will match the PID for your particular diagnostics stream so you don't have to guess!
+
+A stream of events like the following will be displayed as agents change state, calls come/go, and calls are distributed to agents. The kinds of emitted events will vary depending on the selected strategy for the observed queue.
+
+```
+|-------------|----------------------------------------------------------------|
+| 63790338474 | got next winner from [<<"37bc41c35f1738781cb63c57709b73d5">>]  |
+|-------------|----------------------------------------------------------------|
+| 63790338474 | agent 37bc41c35f1738781cb63c57709b73d5 updated in SS           |
+|             |                                                                |
+|             | ringing agents: [<<"37bc41c35f1738781cb63c57709b73d5">>]       |
+|             |                                                                |
+|             | busy agents: []                                                |
+|             |                                                                |
+|             | agent queue: []                                                |
+|-------------|----------------------------------------------------------------|
+```

--- a/src/acdc_maintenance.erl
+++ b/src/acdc_maintenance.erl
@@ -35,6 +35,9 @@
         ,agent_resume/2
         ,agent_queue_login/3
         ,agent_queue_logout/3
+
+        ,start_queue_diagnostics/2
+        ,stop_queue_diagnostics/1
         ]).
 
 -include("acdc.hrl").
@@ -116,7 +119,7 @@ log_current_agent(QueueSup) ->
     QueueM = acdc_queue_sup:manager(QueueSup),
     {_AccountId, QueueId} = acdc_queue_manager:config(QueueM),
     io:format(" ~35s | ~s~n", [QueueId
-                              ,kz_binary:join(acdc_queue_manager:current_agents(QueueM))
+                              ,kz_binary:join(acdc_queue_manager:agents(QueueM))
                               ]).
 
 -spec current_calls(kz_term:ne_binary()) -> 'ok'.
@@ -527,3 +530,31 @@ agent_queue_logout(AcctId, AgentId, QueueId) ->
                ]),
     _ = kz_amqp_worker:cast(Update, fun kapi_acdc_agent:publish_logout_queue/1),
     lager:info("published logout update for agent").
+
+%%------------------------------------------------------------------------------
+%% @doc Start queue diagnostics for the specified queue. Changes to the strategy
+%% state of the queue will be printed to the Erlang console.
+%% @end
+%%------------------------------------------------------------------------------
+-spec start_queue_diagnostics(kz_term:text(), kz_term:text()) -> 'ok'.
+start_queue_diagnostics(AccountId, QueueId) ->
+    case acdc_queue_manager_diag_sup:start_diagnostics(kz_term:to_binary(AccountId), kz_term:to_binary(QueueId)) of
+        {'ok', Pid} ->
+            io:format("This diagnostic process is expensive. Remember to stop diagnostics when you are done!~n"
+                      ++ "To stop: `~p:~p(list_to_pid(\"~s\")).`~n"
+                     ,[?MODULE, 'stop_queue_diagnostics', pid_to_list(Pid)]
+                     );
+        {'error', E} ->
+            io:format("Failed to start queue diagnostics: ~p~n", [E])
+    end.
+
+%%------------------------------------------------------------------------------
+%% @doc Stop queue diagnostics previously started by `start_queue_diagnostics'.
+%% @end
+%%------------------------------------------------------------------------------
+-spec stop_queue_diagnostics(pid() | kz_term:text()) -> any().
+stop_queue_diagnostics(DiagnosticsPid) when is_pid(DiagnosticsPid) ->
+    acdc_queue_manager_diag:stop(DiagnosticsPid);
+stop_queue_diagnostics(DiagnosticsPid) ->
+    PidStr = kz_term:to_list(DiagnosticsPid),
+    stop_queue_diagnostics(list_to_pid(PidStr)).

--- a/src/acdc_queue_fsm.erl
+++ b/src/acdc_queue_fsm.erl
@@ -320,7 +320,7 @@ connect_req('cast', {'member_call_cancel', JObj}, State) ->
 connect_req('cast', {'agent_resp', Resp}, #state{connect_resps=CRs
                                                 ,manager_proc=MgrSrv
                                                 }=State) ->
-    Agents = acdc_queue_manager:current_agents(MgrSrv),
+    Agents = acdc_queue_manager:agents(MgrSrv),
     Resps = [Resp | CRs],
     State1 = State#state{connect_resps=Resps},
     case have_agents_responded(Resps, Agents) of
@@ -777,7 +777,7 @@ maybe_abort_connect_req(OnContinue, CallbackArgs, #state{listener_proc=ListenerS
                                                         ,queue_id=QueueId
                                                         ,member_call=Call
                                                         }=State) ->
-    case acdc_queue_manager:are_agents_available(MgrSrv) of
+    case acdc_queue_manager:has_agents(MgrSrv) of
         'true' -> apply(OnContinue, CallbackArgs ++ [State]);
         'false' ->
             lager:debug("all agents have left the queue, failing call"),

--- a/src/acdc_queue_manager.erl
+++ b/src/acdc_queue_manager.erl
@@ -26,15 +26,17 @@
         ,handle_agent_change/2
         ,handle_queue_member_add/2
         ,handle_queue_member_remove/2
-        ,are_agents_available/1
+        ,has_agents/1
         ,handle_config_change/2
         ,queue_size/1
         ,should_ignore_member_call/3, should_ignore_member_call/4
         ,up_next/2
         ,config/1
         ,status/1
-        ,current_agents/1
+        ,agents/1
         ,refresh/2
+        ,add_diagnostics_receiver/2
+        ,remove_diagnostics_receiver/2
         ]).
 
 %% FSM helpers
@@ -51,8 +53,10 @@
         ]).
 
 -ifdef(TEST).
--export([ss_size/2
-        ,update_strategy_with_agent/5
+-export([update_strategy_with_agent/3
+
+        ,assignable_agent_count/1
+        ,agent_count/1
         ]).
 -endif.
 
@@ -139,11 +143,9 @@ handle_member_call(JObj, Props) ->
     _ = kz_log:put_callid(JObj),
 
     Call = kapps_call:from_json(kz_json:get_value(<<"Call">>, JObj)),
+    Srv = props:get_value('server', Props),
 
-    case are_agents_available(props:get_value('server', Props)
-                             ,props:get_value('enter_when_empty', Props)
-                             )
-    of
+    case has_agents(Srv, props:get_value('enter_when_empty', Props)) of
         'false' ->
             lager:info("no agents are available to take the call, cancel queueing"),
             gen_listener:cast(props:get_value('server', Props)
@@ -153,13 +155,24 @@ handle_member_call(JObj, Props) ->
             start_queue_call(JObj, Props, Call)
     end.
 
--spec are_agents_available(kz_types:server_ref()) -> boolean().
-are_agents_available(Srv) ->
-    are_agents_available(Srv, gen_listener:call(Srv, 'enter_when_empty')).
+%%------------------------------------------------------------------------------
+%% @doc Return true if the queue operated by `Srv' has at least 1 agent or
+%% should behave as if it does (`enter_when_empty' is enabled).
+%% @end
+%%------------------------------------------------------------------------------
+-spec has_agents(kz_types:server_ref()) -> boolean().
+has_agents(Srv) ->
+    has_agents(Srv, gen_listener:call(Srv, 'enter_when_empty')).
 
-are_agents_available(Srv, EnterWhenEmpty) ->
-    agents_available(Srv) > 0
-        orelse EnterWhenEmpty.
+%%------------------------------------------------------------------------------
+%% @doc Return true if `EnterWhenEmpty' is true, otherwise return true if the
+%% queue operated by `Srv' has at least 1 agent.
+%% @end
+%%------------------------------------------------------------------------------
+-spec has_agents(kz_types:server_ref(), boolean()) -> boolean().
+has_agents(Srv, EnterWhenEmpty) ->
+    EnterWhenEmpty
+        orelse gen_listener:call(Srv, 'get_has_agents').
 
 start_queue_call(JObj, Props, Call) ->
     _ = kapps_call:put_callid(Call),
@@ -258,8 +271,12 @@ up_next(Srv, CallId) ->
 -spec config(pid()) -> {kz_term:ne_binary(), kz_term:ne_binary()}.
 config(Srv) -> gen_listener:call(Srv, 'config').
 
--spec current_agents(kz_types:server_ref()) -> kz_term:ne_binaries().
-current_agents(Srv) -> gen_listener:call(Srv, 'current_agents').
+%%------------------------------------------------------------------------------
+%% @doc Return the IDs of the agents in the queue operated by `Srv'.
+%% @end
+%%------------------------------------------------------------------------------
+-spec agents(kz_types:server_ref()) -> kz_term:ne_binaries().
+agents(Srv) -> gen_listener:call(Srv, 'get_agents').
 
 -spec status(pid()) -> kz_term:ne_binaries().
 status(Srv) -> gen_listener:call(Srv, 'status').
@@ -270,12 +287,27 @@ refresh(Mgr, QueueJObj) -> gen_listener:cast(Mgr, {'refresh', QueueJObj}).
 strategy(Srv) -> gen_listener:call(Srv, 'strategy').
 next_winner(Srv) -> gen_listener:call(Srv, 'next_winner').
 
-agents_available(Srv) -> gen_listener:call(Srv, 'agents_available').
-
 -spec pick_winner(pid(), kz_json:objects()) ->
           'undefined' |
           {kz_json:objects(), kz_json:objects()}.
 pick_winner(Srv, Resps) -> pick_winner(Srv, Resps, strategy(Srv), next_winner(Srv)).
+
+%%------------------------------------------------------------------------------
+%% @doc Add a diagnostics receiver to the queue manager as a recipient of
+%% strategy state diagnostic messages.
+%% @end
+%%------------------------------------------------------------------------------
+-spec add_diagnostics_receiver(kz_types:server_ref(), pid()) -> any().
+add_diagnostics_receiver(Srv, Receiver) ->
+    gen_listener:call(Srv, {'add_diagnostics_receiver', Receiver}).
+
+%%------------------------------------------------------------------------------
+%% @doc Remove a previously-added diagnostics receiver from the queue manager.
+%% @end
+%%------------------------------------------------------------------------------
+-spec remove_diagnostics_receiver(kz_types:server_ref(), pid()) -> any().
+remove_diagnostics_receiver(Srv, Receiver) ->
+    gen_listener:call(Srv, {'remove_diagnostics_receiver', Receiver}).
 
 %%%=============================================================================
 %%% gen_server callbacks
@@ -288,6 +320,7 @@ pick_winner(Srv, Resps) -> pick_winner(Srv, Resps, strategy(Srv), next_winner(Sr
 -spec init([pid() | kz_json:object() | kz_term:ne_binary()]) -> {'ok', mgr_state()}.
 init([Super, AccountId, QueueId]) ->
     kz_log:put_callid(<<"mgr_", QueueId/binary>>),
+    put(?KEY_DIAGNOSTICS_PIDS, []),
 
     AcctDb = kzs_util:format_account_db(AccountId),
     {'ok', QueueJObj} = kz_datamgr:open_cache_doc(AcctDb, QueueId),
@@ -324,27 +357,17 @@ handle_call({'should_ignore_member_call', {AccountId, QueueId, CallId}=K}, _, #s
             {'reply', 'true', State#state{ignored_member_calls=dict:erase(K, Dict)}}
     end;
 
-handle_call({'up_next', CallId}, _, #state{strategy_state=SS
-                                          ,current_member_calls=CurrentCalls
-                                          }=State) ->
-    FreeAgents = ss_size(SS, 'free'),
-    Position = call_position(CallId, lists:reverse(CurrentCalls)),
-    {'reply', FreeAgents >= Position, State};
+handle_call({'up_next', CallId}, _, #state{current_member_calls=Calls}=State) ->
+    Position = queue_member_position(CallId, lists:reverse(Calls)),
+    {'reply', assignable_agent_count(State) >= Position, State};
 
 handle_call('config', _, #state{account_id=AccountId
                                ,queue_id=QueueId
                                }=State) ->
     {'reply', {AccountId, QueueId}, State};
 
-handle_call('status', _, #state{strategy_state=#strategy_state{details=Details}}=State) ->
-    Known = [A || {A, {N, _}} <- dict:to_list(Details), N > 0],
-    {'reply', Known, State};
-
 handle_call('strategy', _, #state{strategy=Strategy}=State) ->
     {'reply', Strategy, State, 'hibernate'};
-
-handle_call('agents_available', _, #state{strategy_state=SS}=State) ->
-    {'reply', ss_size(SS, 'logged_in'), State};
 
 handle_call('enter_when_empty', _, #state{enter_when_empty=EnterWhenEmpty}=State) ->
     {'reply', EnterWhenEmpty, State};
@@ -356,6 +379,7 @@ handle_call('next_winner', _, #state{strategy='rr'
                                     }=State) ->
     case queue:out(Agents) of
         {{'value', Winner}, Agents1} ->
+            ?DIAG("got next winner from ~p", [queue:to_list(Agents)]),
             {'reply', Winner, State#state{strategy_state=SS#strategy_state{agents=queue:in(Winner, Agents1)}}, 'hibernate'};
         {'empty', _} ->
             {'reply', 'undefined', State}
@@ -363,22 +387,27 @@ handle_call('next_winner', _, #state{strategy='rr'
 handle_call('next_winner', _, #state{strategy='all'}=State) ->
     {'reply', 'undefined', State};
 
-handle_call('current_agents', _, #state{strategy='rr'
-                                       ,strategy_state=#strategy_state{agents=Q}
-                                       }=State) ->
-    {'reply', queue:to_list(Q), State};
-handle_call('current_agents', _, #state{strategy='mi'
-                                       ,strategy_state=#strategy_state{agents=L}
-                                       }=State) ->
-    {'reply', L, State};
-handle_call('current_agents', _, #state{strategy='all'
-                                       ,strategy_state=#strategy_state{agents=Q}
-                                       }=State) ->
-    {'reply', queue:to_list(Q), State};
+handle_call('get_agents', _, State) ->
+    {'reply', agents_(State), State};
 
-handle_call({'queue_position', CallId}, _, #state{current_member_calls=CurrentCalls}=State) ->
-    Position = call_position(CallId, lists:reverse(CurrentCalls)),
+handle_call('get_has_agents', _, State) ->
+    {'reply', agent_count(State) > 0, State};
+
+handle_call({'queue_position', CallId}, _, #state{current_member_calls=Calls}=State) ->
+    Position = queue_member_position(CallId, lists:reverse(Calls)),
     {'reply', Position, State};
+
+handle_call({'add_diagnostics_receiver', Receiver}, _, State) ->
+    DiagnosticsPids = get(?KEY_DIAGNOSTICS_PIDS),
+    put(?KEY_DIAGNOSTICS_PIDS, [Receiver | DiagnosticsPids]),
+    lager:debug("added ~p to diagnostics receivers", [Receiver]),
+    {'reply', 'ok', State};
+
+handle_call({'remove_diagnostics_receiver', Receiver}, _, State) ->
+    DiagnosticsPids = get(?KEY_DIAGNOSTICS_PIDS),
+    put(?KEY_DIAGNOSTICS_PIDS, lists:delete(Receiver, DiagnosticsPids)),
+    lager:debug("removed ~p from diagnostics receivers", [Receiver]),
+    {'reply', 'ok', State};
 
 handle_call(_Request, _From, State) ->
     {'reply', 'ok', State}.
@@ -454,49 +483,41 @@ handle_cast({'start_worker', N}, #state{account_id=AccountId
     acdc_queue_workers_sup:new_workers(WorkersSup, AccountId, QueueId, N),
     {'noreply', State};
 
-handle_cast({'agent_available', AgentId}, #state{strategy=Strategy
-                                                ,strategy_state=StrategyState
-                                                ,supervisor=QueueSup
-                                                }=State) when is_binary(AgentId) ->
-    lager:info("adding agent ~s to strategy ~s", [AgentId, Strategy]),
-    StrategyState1 = update_strategy_with_agent(Strategy, StrategyState, AgentId, 'add', 'undefined'),
-    maybe_start_queue_workers(QueueSup, ss_size(StrategyState1, 'logged_in')),
-    {'noreply', State#state{strategy_state=StrategyState1}
-    ,'hibernate'};
+handle_cast({'agent_available', AgentId}, #state{supervisor=QueueSup}=State) when is_binary(AgentId) ->
+    Data = #{},
+    StrategyState1 = update_strategy_with_agent(State, AgentId, 'available', Data),
+    State1 = State#state{strategy_state=StrategyState1},
+    maybe_start_queue_workers(QueueSup, agent_count(State1)),
+    {'noreply', State1, 'hibernate'};
 handle_cast({'agent_available', JObj}, State) ->
-    handle_cast({'agent_available', kz_json:get_value(<<"Agent-ID">>, JObj)}, State);
+    handle_cast({'agent_available', kz_json:get_ne_binary_value(<<"Agent-ID">>, JObj)}, State);
 
-handle_cast({'agent_ringing', AgentId}, #state{strategy=Strategy
-                                              ,strategy_state=StrategyState
-                                              }=State) when is_binary(AgentId) ->
+handle_cast({'agent_ringing', AgentId}, #state{strategy=Strategy}=State) when is_binary(AgentId) ->
     lager:info("agent ~s ringing, maybe updating strategy ~s", [AgentId, Strategy]),
 
-    StrategyState1 = maybe_update_strategy(Strategy, StrategyState, AgentId),
-    {'noreply', State#state{strategy_state=StrategyState1}, 'hibernate'};
+    StrategyState1 = update_strategy_with_agent(State, AgentId, 'ringing'),
+    State1 = State#state{strategy_state=StrategyState1},
+    {'noreply', State1, 'hibernate'};
 handle_cast({'agent_ringing', JObj}, State) ->
-    handle_cast({'agent_ringing', kz_json:get_value(<<"Agent-ID">>, JObj)}, State);
+    handle_cast({'agent_ringing', kz_json:get_ne_binary_value(<<"Agent-ID">>, JObj)}, State);
 
-handle_cast({'agent_busy', AgentId}, #state{strategy=Strategy
-                                           ,strategy_state=StrategyState
-                                           }=State) when is_binary(AgentId) ->
+handle_cast({'agent_busy', AgentId}, #state{strategy=Strategy}=State) when is_binary(AgentId) ->
     lager:info("agent ~s busy, maybe updating strategy ~s", [AgentId, Strategy]),
 
-    StrategyState1 = update_strategy_with_agent(Strategy, StrategyState, AgentId, 'remove', 'busy'),
-    {'noreply', State#state{strategy_state=StrategyState1}
-    ,'hibernate'};
+    StrategyState1 = update_strategy_with_agent(State, AgentId, 'busy'),
+    State1 = State#state{strategy_state=StrategyState1},
+    {'noreply', State1, 'hibernate'};
 handle_cast({'agent_busy', JObj}, State) ->
-    handle_cast({'agent_busy', kz_json:get_value(<<"Agent-ID">>, JObj)}, State);
+    handle_cast({'agent_busy', kz_json:get_ne_binary_value(<<"Agent-ID">>, JObj)}, State);
 
-handle_cast({'agent_unavailable', AgentId}, #state{strategy=Strategy
-                                                  ,strategy_state=StrategyState
-                                                  }=State) when is_binary(AgentId) ->
+handle_cast({'agent_unavailable', AgentId}, #state{strategy=Strategy}=State) when is_binary(AgentId) ->
     lager:info("agent ~s unavailable, maybe updating strategy ~s", [AgentId, Strategy]),
 
-    StrategyState1 = update_strategy_with_agent(Strategy, StrategyState, AgentId, 'remove', 'undefined'),
-    {'noreply', State#state{strategy_state=StrategyState1}
-    ,'hibernate'};
+    StrategyState1 = update_strategy_with_agent(State, AgentId, 'unavailable'),
+    State1 = State#state{strategy_state=StrategyState1},
+    {'noreply', State1, 'hibernate'};
 handle_cast({'agent_unavailable', JObj}, State) ->
-    handle_cast({'agent_unavailable', kz_json:get_value(<<"Agent-ID">>, JObj)}, State);
+    handle_cast({'agent_unavailable', kz_json:get_ne_binary_value(<<"Agent-ID">>, JObj)}, State);
 
 handle_cast({'reject_member_call', Call, JObj}, #state{account_id=AccountId
                                                       ,queue_id=QueueId
@@ -528,11 +549,11 @@ handle_cast({'gen_listener',{'is_consuming',_IsConsuming}}, State) ->
 
 handle_cast({'add_queue_member', JObj}, #state{account_id=AccountId
                                               ,queue_id=QueueId
-                                              ,current_member_calls=CurrentCalls
+                                              ,current_member_calls=Calls
                                               ,announcements_config=AnnouncementsConfig
                                               ,announcements_pids=AnnouncementsPids
                                               }=State) ->
-    Position = length(CurrentCalls)+1,
+    Position = length(Calls)+1,
     Call = kapps_call:set_custom_channel_var(<<"Queue-Position">>
                                             ,Position
                                             ,kapps_call:from_json(kz_json:get_value(<<"Call">>, JObj))),
@@ -561,7 +582,7 @@ handle_cast({'add_queue_member', JObj}, #state{account_id=AccountId
                                  AnnouncementsPids#{CallId => Pid}
                          end,
 
-    {'noreply', State#state{current_member_calls=[Call | CurrentCalls]
+    {'noreply', State#state{current_member_calls=[Call | Calls]
                            ,announcements_pids=AnnouncementsPids1
                            }};
 
@@ -640,19 +661,26 @@ start_secondary_queue(AccountId, QueueId) ->
 make_ignore_key(AccountId, QueueId, CallId) ->
     {AccountId, QueueId, CallId}.
 
--spec queue_member(kz_term:ne_binary(), list()) -> kapps_call:call() | 'undefined'.
+-spec queue_member(kz_term:ne_binary(), [kapps_call:call()]) -> kapps_call:call() | 'undefined'.
 queue_member(CallId, Calls) ->
     case queue_member_lookup(CallId, Calls) of
         'undefined' -> 'undefined';
         {Call, _} -> Call
     end.
 
--spec queue_member_lookup(kz_term:ne_binary(), list()) ->
+-spec queue_member_position(kz_term:ne_binary(), [kapps_call:call()]) -> kz_term:api_pos_integer().
+queue_member_position(CallId, Calls) ->
+    case queue_member_lookup(CallId, Calls) of
+        'undefined' -> 'undefined';
+        {_, Position} -> Position
+    end.
+
+-spec queue_member_lookup(kz_term:ne_binary(), [kapps_call:call()]) ->
           {kapps_call:call(), pos_integer()} | 'undefined'.
 queue_member_lookup(CallId, Calls) ->
     queue_member_lookup(CallId, Calls, 1).
 
--spec queue_member_lookup(kz_term:ne_binary(), list(), pos_integer()) ->
+-spec queue_member_lookup(kz_term:ne_binary(), [kapps_call:call()], pos_integer()) ->
           {kapps_call:call(), pos_integer()} | 'undefined'.
 queue_member_lookup(_, [], _) -> 'undefined';
 queue_member_lookup(CallId, [Call|Calls], Position) ->
@@ -714,136 +742,229 @@ pick_winner(_Mgr, CRs, 'mi', _) ->
 pick_winner(_Mgr, CRs, 'all', _AgentId) ->
     {CRs, []}.
 
--spec update_strategy_with_agent(queue_strategy(), strategy_state(), kz_term:ne_binary(), 'add' | 'remove', 'busy' | 'undefined') ->
+%%------------------------------------------------------------------------------
+%% @doc Return the IDs of the agents that are ready to take calls.
+%% @end
+%%------------------------------------------------------------------------------
+-spec ready_agents(mgr_state()) -> kz_term:ne_binaries().
+ready_agents(#state{strategy=Strategy
+                   ,strategy_state=#strategy_state{agents=Agents}
+                   }) ->
+    ready_agents(Strategy, Agents).
+
+%%------------------------------------------------------------------------------
+%% @doc Return the IDs of the agents that are ready to take calls, based on the
+%% queue strategy.
+%% @end
+%%------------------------------------------------------------------------------
+-spec ready_agents(queue_strategy(), queue_strategy_state()) -> kz_term:ne_binaries().
+ready_agents('rr', AgentQueue) -> queue:to_list(AgentQueue);
+ready_agents('mi', AgentL) -> AgentL;
+ready_agents('all', AgentQueue) -> queue:to_list(AgentQueue).
+
+%%------------------------------------------------------------------------------
+%% @doc Return the count of agents that are ready to take calls.
+%% @end
+%%------------------------------------------------------------------------------
+-spec ready_agent_count(mgr_state()) -> non_neg_integer().
+ready_agent_count(#state{strategy=Strategy
+                        ,strategy_state=#strategy_state{agents=Agents}
+                        }) ->
+    ready_agent_count(Strategy, Agents).
+
+%%------------------------------------------------------------------------------
+%% @doc Return the count of agents that are ready to take calls, based on the
+%% queue strategy.
+%% @end
+%%------------------------------------------------------------------------------
+-spec ready_agent_count(queue_strategy(), queue_strategy_state()) -> non_neg_integer().
+ready_agent_count('rr', AgentQueue) -> queue:len(AgentQueue);
+ready_agent_count('mi', AgentL) -> length(AgentL);
+ready_agent_count('all', AgentQueue) -> queue:len(AgentQueue).
+
+%%------------------------------------------------------------------------------
+%% @doc Return the count of agents that are eligible to be assigned to a waiting
+%% call.
+%% @end
+%%------------------------------------------------------------------------------
+-spec assignable_agent_count(mgr_state()) -> non_neg_integer().
+assignable_agent_count(#state{strategy=Strategy
+                             ,strategy_state=#strategy_state{agents=Agents
+                                                            ,ringing_agents=RingingAgents
+                                                            }
+                             }) ->
+    assignable_agent_count(Strategy, Agents, RingingAgents).
+
+%%------------------------------------------------------------------------------
+%% @doc Return the count of agents that are eligible to be assigned to a waiting
+%% call, based on the queue strategy. Round Robin, Most Idle, and Ring All
+%% strategies must include ringing agents in the count to ensure maximal
+%% simultaneous ringing.
+%% @end
+%%------------------------------------------------------------------------------
+-spec assignable_agent_count(queue_strategy(), queue_strategy_state(), kz_term:ne_binaries()) ->
+          non_neg_integer().
+assignable_agent_count('rr', AgentQueue, RingingAgents) ->
+    ready_agent_count('rr', AgentQueue) + length(RingingAgents);
+assignable_agent_count('mi', AgentL, RingingAgents) ->
+    ready_agent_count('mi', AgentL) + length(RingingAgents);
+assignable_agent_count('all', AgentQueue, RingingAgents) ->
+    ready_agent_count('all', AgentQueue) + length(RingingAgents).
+
+%%------------------------------------------------------------------------------
+%% @doc Return the IDs of all agents.
+%% @end
+%%------------------------------------------------------------------------------
+-spec agents_(mgr_state()) -> kz_term:ne_binaries().
+agents_(#state{strategy_state=#strategy_state{ringing_agents=RingingAgents
+                                             ,busy_agents=BusyAgents
+                                             }
+              }=State) ->
+    ready_agents(State) ++ RingingAgents ++ BusyAgents.
+
+%%------------------------------------------------------------------------------
+%% @doc Return the count of all agents.
+%% @end
+%%------------------------------------------------------------------------------
+-spec agent_count(mgr_state()) -> non_neg_integer().
+agent_count(#state{strategy_state=#strategy_state{ringing_agents=RingingAgents
+                                                 ,busy_agents=BusyAgents
+                                                 }
+                  }=State) ->
+    ready_agent_count(State) + length(RingingAgents) + length(BusyAgents).
+
+%%------------------------------------------------------------------------------
+%% @doc Update the strategy state with the change of availability for `AgentId'.
+%% @end
+%%------------------------------------------------------------------------------
+-spec update_strategy_with_agent(mgr_state(), kz_term:ne_binary(), agent_change()) -> strategy_state().
+update_strategy_with_agent(State, AgentId, Change) ->
+    update_strategy_with_agent(State, AgentId, Change, #{}).
+
+%%------------------------------------------------------------------------------
+%% @doc Update the strategy state with the change of availability for `AgentId'.
+%% If diagnostics are enabled, the strategy state changes will be forwarded to
+%% the diagnostics receivers.
+%% @end
+%%------------------------------------------------------------------------------
+-spec update_strategy_with_agent(mgr_state(), kz_term:ne_binary(), agent_change(), agent_change_data()) ->
           strategy_state().
-update_strategy_with_agent('rr', #strategy_state{agents=AgentQueue}=SS, AgentId, 'add', Busy) ->
-    case queue:member(AgentId, AgentQueue) of
-        'true' -> set_busy(AgentId, Busy, SS);
-        'false' -> set_busy(AgentId, Busy, add_agent('rr', AgentId, SS))
-    end;
-update_strategy_with_agent('rr', SS, AgentId, 'remove', 'busy') ->
-    set_busy(AgentId, 'busy', SS);
-update_strategy_with_agent('rr', #strategy_state{agents=AgentQueue}=SS, AgentId, 'remove', Busy) ->
-    case queue:member(AgentId, AgentQueue) of
-        'false' -> set_busy(AgentId, Busy, SS);
-        'true' -> set_busy(AgentId, Busy, remove_agent('rr', AgentId, SS))
-    end;
-update_strategy_with_agent('mi', #strategy_state{agents=AgentL}=SS, AgentId, 'add', Busy) ->
-    case lists:member(AgentId, AgentL) of
-        'true' -> set_busy(AgentId, Busy, SS);
-        'false' -> set_busy(AgentId, Busy, add_agent('mi', AgentId, SS))
-    end;
-update_strategy_with_agent('mi', SS, AgentId, 'remove', 'busy') ->
-    set_busy(AgentId, 'busy', SS);
-update_strategy_with_agent('mi', #strategy_state{agents=AgentL}=SS, AgentId, 'remove', Busy) ->
-    case lists:member(AgentId, AgentL) of
-        'false' -> set_busy(AgentId, Busy, SS);
-        'true' -> set_busy(AgentId, Busy, remove_agent('mi', AgentId, SS))
-    end;
-update_strategy_with_agent('all', #strategy_state{agents=AgentQueue}=SS, AgentId, 'add', Busy) ->
-    case queue:member(AgentId, AgentQueue) of
-        'true' -> set_busy(AgentId, Busy, SS);
-        'false' -> set_busy(AgentId, Busy, add_agent('all', AgentId, SS))
-    end;
-update_strategy_with_agent('all', SS, AgentId, 'remove', 'busy') ->
-    set_busy(AgentId, 'busy', SS);
-update_strategy_with_agent('all', #strategy_state{agents=AgentQueue}=SS, AgentId, 'remove', Busy) ->
-    case queue:member(AgentId, AgentQueue) of
-        'false' -> set_busy(AgentId, Busy, SS);
-        'true' -> set_busy(AgentId, Busy, remove_agent('all', AgentId, SS))
-    end.
+update_strategy_with_agent(#state{strategy=Strategy
+                                 ,strategy_state=SS
+                                 }=State, AgentId, Change, Data) ->
+    SS1 = set_flag(AgentId, Change, SS),
+    State1 = State#state{strategy_state=SS1},
+    SS2 = do_update_strategy_with_agent(State1, AgentId, Change, Data),
+    #strategy_state{agents=Agents
+                   ,ringing_agents=RingingAgents
+                   ,busy_agents=BusyAgents
+                   } = SS2,
+    maybe_send_diagnostics_for_strategy_update(Strategy, Agents, AgentId, RingingAgents, BusyAgents),
+    SS2.
 
--spec add_agent(queue_strategy(), kz_term:ne_binary(), strategy_state()) -> strategy_state().
-add_agent('rr', AgentId, #strategy_state{agents=AgentQueue
-                                        ,details=Details
-                                        }=SS) ->
-    SS#strategy_state{agents=queue:in(AgentId, AgentQueue)
-                     ,details=incr_agent(AgentId, Details)
-                     };
-add_agent('mi', AgentId, #strategy_state{agents=AgentL
-                                        ,details=Details
-                                        }=SS) ->
-    SS#strategy_state{agents=[AgentId | AgentL]
-                     ,details=incr_agent(AgentId, Details)
-                     };
-add_agent('all', AgentId, #strategy_state{agents=AgentQueue
-                                         ,details=Details
-                                         }=SS) ->
-    SS#strategy_state{agents=queue:in(AgentId, AgentQueue)
-                     ,details=incr_agent(AgentId, Details)
-                     }.
+%%------------------------------------------------------------------------------
+%% @doc Update the strategy state with the change of availability for `AgentId',
+%% based on the queue strategy.
+%% @end
+%%------------------------------------------------------------------------------
+-spec do_update_strategy_with_agent(mgr_state(), kz_term:ne_binary(), agent_change(), agent_change_data()) ->
+          strategy_state().
+do_update_strategy_with_agent(#state{strategy='rr'
+                                    ,strategy_state=SS
+                                    }, AgentId, Change, Data) ->
+    update_rr_strategy_with_agent(SS, AgentId, Change, Data);
+do_update_strategy_with_agent(#state{strategy='mi'
+                                    ,strategy_state=SS
+                                    }, AgentId, Change, _) ->
+    update_mi_strategy_with_agent(SS, AgentId, Change);
+do_update_strategy_with_agent(#state{strategy='all'
+                                    ,strategy_state=SS
+                                    }, AgentId, Change, _) ->
+    update_all_strategy_with_agent(SS, AgentId, Change).
 
--spec remove_agent(queue_strategy(), kz_term:ne_binary(), strategy_state()) -> strategy_state().
-remove_agent('rr', AgentId, #strategy_state{agents=AgentQueue
-                                           ,details=Details
-                                           }=SS) ->
-    case dict:find(AgentId, Details) of
-        {'ok', {Count, _}} when Count > 1 ->
-            SS#strategy_state{details=decr_agent(AgentId, Details)};
-        _ ->
-            SS#strategy_state{agents=queue:filter(fun(AgentId1) when AgentId =:= AgentId1 -> 'false';
-                                                     (_) -> 'true' end
-                                                 ,AgentQueue
-                                                 )
-                             ,details=decr_agent(AgentId, Details)
-                             }
-    end;
-remove_agent('mi', AgentId, #strategy_state{agents=AgentL
-                                           ,details=Details
-                                           }=SS) ->
-    case dict:find(AgentId, Details) of
-        {'ok', {Count, _}} when Count > 1 ->
-            SS#strategy_state{details=decr_agent(AgentId, Details)};
-        _ ->
-            SS#strategy_state{agents=[A || A <- AgentL, A =/= AgentId]
-                             ,details=decr_agent(AgentId, Details)
-                             }
-    end;
-remove_agent('all', AgentId, #strategy_state{agents=AgentQueue
-                                            ,details=Details
-                                            }=SS) ->
-    case dict:find(AgentId, Details) of
-        {'ok', {Count, _}} when Count > 1 ->
-            SS#strategy_state{details=decr_agent(AgentId, Details)};
-        _ ->
-            SS#strategy_state{agents=queue:filter(fun(AgentId1) when AgentId =:= AgentId1 -> 'false';
-                                                     (_) -> 'true' end
-                                                 ,AgentQueue
-                                                 )
-                             ,details=decr_agent(AgentId, Details)
-                             }
-    end.
+%%------------------------------------------------------------------------------
+%% @doc Update the Round Robin strategy state with the change of availability
+%% for `AgentId'.
+%% @end
+%%------------------------------------------------------------------------------
+-spec update_rr_strategy_with_agent(strategy_state(), kz_term:ne_binary(), agent_change(), agent_change_data()) ->
+          strategy_state().
+update_rr_strategy_with_agent(#strategy_state{agents=AgentQueue}=SS
+                             ,AgentId, 'available', _
+                             ) ->
+    Msg = io_lib:format("adding agent ~s to strategy rr", [AgentId]),
+    {IsReAdd, AgentQueue1} = acdc_util:queue_remove(AgentId, AgentQueue),
+    Msg1 = case IsReAdd of
+               'true' -> ["re-", Msg];
+               'false' -> Msg
+           end,
+    lager:info(Msg1),
+    SS#strategy_state{agents=queue:in(AgentId, AgentQueue1)};
+update_rr_strategy_with_agent(#strategy_state{agents=AgentQueue}=SS, AgentId, _, _) ->
+    {Removed, AgentQueue1} = acdc_util:queue_remove(AgentId, AgentQueue),
+    Removed
+        andalso lager:info("removing agent ~s from strategy rr", [AgentId]),
+    SS#strategy_state{agents=AgentQueue1}.
 
--spec incr_agent(kz_term:ne_binary(), dict:dict(kz_term:ne_binary(), ss_details())) ->
-          dict:dict(kz_term:ne_binary(), ss_details()).
-incr_agent(AgentId, Details) ->
-    dict:update(AgentId, fun({Count, Busy}) -> {Count + 1, Busy} end, {1, 'undefined'}, Details).
+%%------------------------------------------------------------------------------
+%% @doc Update the Most Idle strategy state with the change of availability for
+%% `AgentId'.
+%% @end
+%%------------------------------------------------------------------------------
+-spec update_mi_strategy_with_agent(strategy_state(), kz_term:ne_binary(), agent_change()) ->
+          strategy_state().
+update_mi_strategy_with_agent(#strategy_state{agents=AgentL}=SS, AgentId, 'available') ->
+    lists:member(AgentId, AgentL)
+        orelse lager:info("adding agent ~s to strategy mi", [AgentId]),
+    AgentL1 = [AgentId | lists:delete(AgentId, AgentL)],
+    SS#strategy_state{agents=AgentL1};
+update_mi_strategy_with_agent(#strategy_state{agents=AgentL}=SS, AgentId, _) ->
+    lists:member(AgentId, AgentL)
+        andalso lager:info("removing agent ~s from strategy mi", [AgentId]),
+    AgentL1 = lists:delete(AgentId, AgentL),
+    SS#strategy_state{agents=AgentL1}.
 
--spec decr_agent(kz_term:ne_binary(), dict:dict(kz_term:ne_binary(), ss_details())) ->
-          dict:dict(kz_term:ne_binary(), ss_details()).
-decr_agent(AgentId, Details) ->
-    dict:update(AgentId, fun({Count, Busy}) when Count > 1 -> {Count - 1, Busy};
-                            ({_, Busy}) -> {0, Busy} end
-               ,{0, 'undefined'}, Details).
+%%------------------------------------------------------------------------------
+%% @doc Update the Ring All strategy state with the change of availability for
+%% `AgentId'.
+%% @end
+%%------------------------------------------------------------------------------
+-spec update_all_strategy_with_agent(strategy_state(), kz_term:ne_binary(), agent_change()) ->
+          strategy_state().
+update_all_strategy_with_agent(#strategy_state{agents=AgentQueue}=SS, AgentId, 'available') ->
+    Msg = io_lib:format("adding agent ~s to strategy all", [AgentId]),
+    {IsReAdd, AgentQueue1} = acdc_util:queue_remove(AgentId, AgentQueue),
+    Msg1 = case IsReAdd of
+               'true' -> ["re-", Msg];
+               'false' -> Msg
+           end,
+    lager:info(Msg1),
+    SS#strategy_state{agents=queue:in(AgentId, AgentQueue1)};
+update_all_strategy_with_agent(#strategy_state{agents=AgentQueue}=SS, AgentId, _) ->
+    {Removed, AgentQueue1} = acdc_util:queue_remove(AgentId, AgentQueue),
+    Removed
+        andalso lager:info("removing agent ~s from strategy all", [AgentId]),
+    SS#strategy_state{agents=AgentQueue1}.
 
--spec set_busy(kz_term:ne_binary(), 'busy' | 'undefined', strategy_state()) -> strategy_state().
-set_busy(AgentId, Busy, #strategy_state{details=Details}=SS) ->
-    SS#strategy_state{details=dict:update(AgentId, fun({Count, _}) -> {Count, Busy} end, {0, Busy}, Details)}.
+%%------------------------------------------------------------------------------
+%% @doc Apply strategy state changes based on the agent change flag (ringing/
+%% busy).
+%% @end
+%%------------------------------------------------------------------------------
+-spec set_flag(kz_term:ne_binary(), agent_change(), strategy_state()) -> strategy_state().
+set_flag(AgentId, Flag, #strategy_state{ringing_agents=RingingAgents
+                                       ,busy_agents=BusyAgents
+                                       }=SS) ->
+    RingingAgents1 = lists:delete(AgentId, RingingAgents),
+    BusyAgents1 = lists:delete(AgentId, BusyAgents),
+    SS1 = SS#strategy_state{ringing_agents=RingingAgents1
+                           ,busy_agents=BusyAgents1
+                           },
 
-maybe_update_strategy('mi', StrategyState, _AgentId) -> StrategyState;
-maybe_update_strategy('rr', #strategy_state{agents=AgentQueue}=SS, AgentId) ->
-    case queue:out(AgentQueue) of
-        {{'value', AgentId}, AgentQueue1} ->
-            lager:debug("agent ~s was front of queue, moving", [AgentId]),
-            SS#strategy_state{agents=queue:in(AgentId, AgentQueue1)};
-        _ -> SS
-    end;
-maybe_update_strategy('all', #strategy_state{agents=AgentQueue}=SS, AgentId) ->
-    case queue:out(AgentQueue) of
-        {{'value', AgentId}, AgentQueue1} ->
-            lager:debug("agent ~s was front of queue, moving", [AgentId]),
-            SS#strategy_state{agents=queue:in(AgentId, AgentQueue1)};
-        _ -> SS
+    case Flag of
+        'ringing' -> SS1#strategy_state{ringing_agents=[AgentId | RingingAgents1]};
+        'busy' -> SS1#strategy_state{busy_agents=[AgentId | BusyAgents1]};
+        _ -> SS1
     end.
 
 %% If A's idle time is greater, it should come before B
@@ -889,42 +1010,11 @@ create_ss_agents('rr') -> queue:new();
 create_ss_agents('mi') -> [];
 create_ss_agents('all') -> queue:new().
 
--spec call_position(kz_term:ne_binary(), [kapps_call:call()]) -> kz_term:api_integer().
-call_position(CallId, Calls) ->
-    call_position(CallId, Calls, 1).
-
--spec call_position(kz_term:ne_binary(), [kapps_call:call()], pos_integer()) -> pos_integer().
-call_position(_, [], _) ->
-    'undefined';
-call_position(CallId, [Call|Calls], Position) ->
-    case kapps_call:call_id(Call) of
-        CallId -> Position;
-        _ -> call_position(CallId, Calls, Position + 1)
-    end.
-
--spec ss_size(strategy_state(), 'free' | 'logged_in') -> integer().
-ss_size(#strategy_state{agents=Agents}, 'logged_in') ->
-    case queue:is_queue(Agents) of
-        'true' -> queue:len(Agents);
-        'false' -> length(Agents)
-    end;
-ss_size(#strategy_state{agents=Agents
-                       ,details=Details
-                       }, 'free') when is_list(Agents) ->
-    lists:foldl(fun(AgentId, Count) ->
-                        case dict:find(AgentId, Details) of
-                            {'ok', {ProcCount, 'undefined'}} when ProcCount > 0 -> Count + 1;
-                            _ -> Count
-                        end
-                end, 0, Agents);
-ss_size(#strategy_state{agents=Agents}=SS, 'free') ->
-    ss_size(SS#strategy_state{agents=queue:to_list(Agents)}, 'free').
-
-maybe_start_queue_workers(QueueSup, AgentCount) ->
+maybe_start_queue_workers(QueueSup, Count) ->
     WSup = acdc_queue_sup:workers_sup(QueueSup),
     case acdc_queue_workers_sup:worker_count(WSup) of
-        N when N >= AgentCount -> 'ok';
-        N when N < AgentCount -> gen_listener:cast(self(), {'start_worker', AgentCount-N})
+        N when N >= Count -> 'ok';
+        N when N < Count -> gen_listener:cast(self(), {'start_worker', Count - N})
     end.
 
 -spec update_properties(kz_json:object(), mgr_state()) -> mgr_state().
@@ -975,3 +1065,59 @@ remove_queue_member(CallId, #state{current_member_calls=CurrentCalls
     State#state{current_member_calls=lists:keydelete(CallId, 2, CurrentCalls)
                ,announcements_pids=AnnouncementsPids1
                }.
+
+%%------------------------------------------------------------------------------
+%% @doc If there is at least one diagnostics receiver attached to the queue
+%% manager, send the diagnostics message returned by `GetDiagnosticsMessage' to
+%% all the diagnostics receivers. `GetDiagnosticsMessage' is a factory function
+%% so that the diagnostics message generation is a noop when diagnostics are
+%% disabled for the queue.
+%% @end
+%%------------------------------------------------------------------------------
+-spec maybe_send_diagnostics(fun(() -> iolist())) -> 'ok'.
+maybe_send_diagnostics(GetDiagnosticsMessage) ->
+    case get(?KEY_DIAGNOSTICS_PIDS) of
+        'undefined' -> 'ok';
+        [] -> 'ok';
+        Pids ->
+            Message = GetDiagnosticsMessage(),
+            acdc_queue_manager_diag_sup:send_diagnostics(Pids, Message)
+    end.
+
+%%------------------------------------------------------------------------------
+%% @doc Prepare a diagnostics payload for an update of the strategy state due to
+%% an agent state change (e.g. ringing/busy). The diagnostics will only be
+%% prepared if there is at least one diagnostics receiver attached to the queue
+%% manager.
+%% @end
+%%------------------------------------------------------------------------------
+-spec maybe_send_diagnostics_for_strategy_update(queue_strategy()
+                                                ,queue_strategy_state()
+                                                ,kz_term:ne_binary()
+                                                ,kz_term:ne_binaries()
+                                                ,kz_term:ne_binaries()
+                                                ) -> 'ok'.
+maybe_send_diagnostics_for_strategy_update(Strategy
+                                          ,AgentQueue
+                                          ,AgentId
+                                          ,RingingAgents
+                                          ,BusyAgents
+                                          ) when Strategy =:= 'rr'; Strategy =:= 'all' ->
+    Message = "agent ~s updated in SS~n~n"
+        ++ "ringing agents: ~p~n~n"
+        ++ "busy agents: ~p~n~n"
+        ++ "agent queue: ~p",
+    ?DIAG(Message
+         ,[AgentId
+          ,RingingAgents
+          ,BusyAgents
+          ,queue:to_list(AgentQueue)
+          ]);
+maybe_send_diagnostics_for_strategy_update('mi', AgentL, AgentId, RingingAgents, BusyAgents) ->
+    Message = "agent ~s updated in SS~n~n"
+        ++ "ringing agents: ~p~n~n"
+        ++ "busy agents: ~p~n~n"
+        ++ "agent list: ~p",
+    ?DIAG(Message
+         ,[AgentId, RingingAgents, BusyAgents, AgentL]
+         ).

--- a/src/acdc_queue_manager.hrl
+++ b/src/acdc_queue_manager.hrl
@@ -1,14 +1,20 @@
 -ifndef(ACDC_QUEUE_MANAGER_HRL).
 
+%% Used for shipping diagnostics to `acdc_queue_manager_diag'
+-define(KEY_DIAGNOSTICS_PIDS, 'diagnostics_pids').
+-define(DIAG(Message), ?DIAG(Message, [])).
+-define(DIAG(Message, Args)
+       ,maybe_send_diagnostics(fun() -> io_lib:format(Message, Args) end)
+       ).
+
 %% rr :: Round Robin
 %% mi :: Most Idle
 -type queue_strategy() :: 'rr' | 'mi' | 'all'.
 
 -type queue_strategy_state() :: queue:queue() | kz_term:ne_binaries().
--type ss_details() :: {non_neg_integer(), 'busy' | 'undefined'}.
--record(strategy_state, {agents :: queue_strategy_state() | 'undefined'
-                                   %% details include # of agent processes and availability
-                        ,details = dict:new() :: dict:dict(kz_term:ne_binary(), ss_details())
+-record(strategy_state, {agents :: queue_strategy_state()
+                        ,ringing_agents = [] :: kz_term:ne_binaries()
+                        ,busy_agents = [] :: kz_term:ne_binaries()
                         }).
 -type strategy_state() :: #strategy_state{}.
 
@@ -21,11 +27,14 @@
                ,known_agents = dict:new() :: dict:dict() % how many agent processes are available {AgentId, Count}
                ,enter_when_empty = 'true' :: boolean() % allow caller into queue if no agents are logged in
                ,moh :: kz_term:api_ne_binary()
-               ,current_member_calls = [] :: list() % ordered list of current members waiting
+               ,current_member_calls = [] :: [kapps_call:call()] % list of current members waiting
                ,announcements_config = [] :: kz_term:proplist()
                ,announcements_pids = #{} :: announcements_pids()
                }).
 -type mgr_state() :: #state{}.
+
+-type agent_change() :: 'available' | 'ringing' | 'busy' | 'unavailable'.
+-type agent_change_data() :: #{}.
 
 -define(ACDC_QUEUE_MANAGER_HRL, 'true').
 -endif.

--- a/src/acdc_queue_manager_diag.erl
+++ b/src/acdc_queue_manager_diag.erl
@@ -1,0 +1,305 @@
+%%%-----------------------------------------------------------------------------
+%%% @copyright (C) 2021-, Ooma Inc.
+%%% @doc Allows tracing strategy state changes in acdc_queue_manager
+%%%
+%%% @author Daniel Finke
+%%% @end
+%%%-----------------------------------------------------------------------------
+-module(acdc_queue_manager_diag).
+-behaviour(gen_server).
+
+%% API
+-export([start_link/3
+        ,stop/1
+        ]).
+-export([send_diagnostics/2]).
+
+%% gen_server callbacks
+-export([init/1
+        ,handle_call/3
+        ,handle_cast/2
+        ,handle_info/2
+        ,terminate/2
+        ,code_change/3
+        ]).
+
+-include("acdc.hrl").
+
+-define(MESSAGE_LINE_LENGTH, 100).
+
+-record(state, {account_id            :: kz_term:ne_binary()
+               ,queue_id              :: kz_term:ne_binary()
+               ,manager               :: kz_term:api_pid()
+               ,observer              :: kz_term:api_pid()
+               ,observer_group_leader :: kz_term:api_pid()
+               }).
+-type state() :: #state{}.
+
+%%%=============================================================================
+%%% API
+%%%=============================================================================
+
+%%------------------------------------------------------------------------------
+%% @doc Starts the server
+%% @end
+%%------------------------------------------------------------------------------
+-spec start_link(kz_term:ne_binary(), kz_term:ne_binary(), pid()) -> kz_types:startlink_ret().
+start_link(AccountId, QueueId, Observer) ->
+    gen_server:start_link(?MODULE, {AccountId, QueueId, Observer}, []).
+
+%%------------------------------------------------------------------------------
+%% @doc Stops the server
+%% @end
+%%------------------------------------------------------------------------------
+-spec stop(kz_types:server_ref()) -> 'ok'.
+stop(Srv) ->
+    gen_server:call(Srv, 'stop').
+
+%%------------------------------------------------------------------------------
+%% @doc Send a diagnostics message to `Srv'
+%% @end
+%%------------------------------------------------------------------------------
+-spec send_diagnostics(kz_types:server_ref(), iolist()) -> 'ok'.
+send_diagnostics(Srv, Message) ->
+    gen_server:cast(Srv, {'send_diagnostics', Message}).
+
+%%%=============================================================================
+%%% gen_server callbacks
+%%%=============================================================================
+
+%%------------------------------------------------------------------------------
+%% @doc Initializes the server.
+%% @end
+%%------------------------------------------------------------------------------
+-spec init({kz_term:ne_binary(), kz_term:ne_binary(), pid()}) -> {'ok', state()} | {'stop', any()}.
+init({AccountId, QueueId, Observer}) ->
+    kz_log:put_callid(<<AccountId/binary, "-", QueueId/binary, "-", (kz_term:to_binary(Observer))/binary>>),
+
+    InitFuns = [{fun set_up_group_leader/1, [Observer], #state.observer_group_leader}
+               ,{fun monitor_manager/2, [AccountId, QueueId], #state.manager}
+               ,{fun print_header/0, []}
+               ],
+    case lists:foldl(fun init_fold/2, [], InitFuns) of
+        {'error', _}=E -> {'stop', E};
+        StateAssignments ->
+            lager:debug("started"),
+
+            {'ok', lists:foldl(fun({Index, Value}, State) -> setelement(Index, State, Value) end
+                              ,#state{account_id=AccountId
+                                     ,queue_id=QueueId
+                                     }
+                              ,StateAssignments
+                              )}
+    end.
+
+%%------------------------------------------------------------------------------
+%% @doc Handling call messages.
+%% @end
+%%------------------------------------------------------------------------------
+-spec handle_call(any(), kz_term:pid_ref(), state()) -> kz_types:handle_call_ret_state(state()).
+handle_call('stop', _From, State) ->
+    {'stop', 'normal', 'ok', State};
+
+handle_call(_Request, _From, State) ->
+    lager:debug("unhandled call: ~p", [_Request]),
+    {'reply', 'ok', State}.
+
+%%------------------------------------------------------------------------------
+%% @doc Handling cast messages.
+%% @end
+%%------------------------------------------------------------------------------
+-spec handle_cast(any(), state()) -> kz_types:handle_cast_ret_state(state()).
+handle_cast({'send_diagnostics', Message}, State) ->
+    print(lists:flatten(Message)),
+    {'noreply', State};
+
+handle_cast(_Message, State) ->
+    lager:debug("unhandled cast: ~p", [_Message]),
+    {'noreply', State}.
+
+%%------------------------------------------------------------------------------
+%% @doc Handling all non call/cast messages.
+%% @end
+%%------------------------------------------------------------------------------
+-spec handle_info(any(), state()) -> kz_types:handle_info_ret_state(state()).
+handle_info({'DOWN', _, 'process', Manager, Reason}, #state{manager=Manager}=State) ->
+    %% Stop the diagnostics process if the manager goes down
+    print(io_lib:format("manager pid ~p went down (~p)", [Manager, Reason])),
+    {'stop', 'normal', State};
+handle_info({'DOWN', _, 'process', Pid, Reason}, #state{observer=Observer
+                                                       ,observer_group_leader=GroupLeader
+                                                       }=State) when Observer =:= Pid; GroupLeader =:= Pid ->
+    %% Stop the diagnostics process if the observer goes down to avoid wasting resources for
+    %% diagnostics
+    lager:debug("observer pid ~p went down (~p)", [Pid, Reason]),
+    {'stop', 'normal', State};
+handle_info(_Info, State) ->
+    lager:debug("unhandled message: ~p", [_Info]),
+    {'noreply', State}.
+
+%%------------------------------------------------------------------------------
+%% @doc This function is called by a `gen_server' when it is about to
+%% terminate. It should be the opposite of `Module:init/1' and do any
+%% necessary cleaning up. When it returns, the `gen_server' terminates
+%% with Reason. The return value is ignored.
+%% @end
+%%------------------------------------------------------------------------------
+-spec terminate(any(), state()) -> 'ok'.
+terminate(_Reason, #state{manager=Manager}) ->
+    catch acdc_queue_manager:remove_diagnostics_receiver(Manager, self()),
+
+    catch print(io_lib:format("stopping diagnostics: ~p", [_Reason])),
+    lager:debug("terminating: ~p", [_Reason]).
+
+%%------------------------------------------------------------------------------
+%% @doc Convert process state when code is changed.
+%% @end
+%%------------------------------------------------------------------------------
+-spec code_change(any(), state(), any()) -> {'ok', state()}.
+code_change(_OldVsn, State, _Extra) ->
+    {'ok', State}.
+
+%%%=============================================================================
+%%% Internal functions
+%%%=============================================================================
+
+%%------------------------------------------------------------------------------
+%% @doc Fold over a list of initialization funs, short-circuiting to return an
+%% error if one occurs during any of those funs.
+%% @end
+%%------------------------------------------------------------------------------
+init_fold(_, {'error', _}=E) -> E;
+init_fold({Fun, Args}, StateAssignments) ->
+    apply(Fun, Args),
+    StateAssignments;
+init_fold({Fun, Args, StateAssignment}, StateAssignments) ->
+    case apply(Fun, Args) of
+        {'error', _}=E -> E;
+        InitFunResult ->
+            [{StateAssignment, InitFunResult} | StateAssignments]
+    end.
+
+%%------------------------------------------------------------------------------
+%% @doc Set the group leader of the diagnostics process to the same one as the
+%% observer and monitor both the observer and group leader processes.
+%% @end
+%%------------------------------------------------------------------------------
+set_up_group_leader(Observer) ->
+    case get_observer_group_leader(Observer) of
+        'undefined' -> {'error', 'unknown_group_leader'};
+        GroupLeader ->
+            group_leader(GroupLeader, self()),
+            monitor('process', Observer),
+            monitor('process', GroupLeader),
+            GroupLeader
+    end.
+
+%%------------------------------------------------------------------------------
+%% @doc Find the `acdc_queue_manager' process for the queue to be observed and
+%% monitor it. Also inform the manager process that it should send diagnostics
+%% to this process.
+%% @end
+%%------------------------------------------------------------------------------
+monitor_manager(AccountId, QueueId) ->
+    case acdc_queues_sup:find_queue_supervisor(AccountId, QueueId) of
+        'undefined' -> {'error', 'manager_process_not_found'};
+        QueueSup ->
+            Manager = acdc_queue_sup:manager(QueueSup),
+            monitor_manager(Manager)
+    end.
+
+%%------------------------------------------------------------------------------
+%% @doc Inform a manager process that it should send diagnostics to this
+%% process.
+%% @end
+%%------------------------------------------------------------------------------
+monitor_manager(Manager) ->
+    try acdc_queue_manager:add_diagnostics_receiver(Manager, self()) of
+        'ok' ->
+            monitor('process', Manager),
+            Manager
+    catch
+        'error':E:Stacktrace -> {'error', {E, Stacktrace}}
+    end.
+
+%%------------------------------------------------------------------------------
+%% @doc Get the group leader of the process identified by `Observer'.
+%% @end
+%%------------------------------------------------------------------------------
+-spec get_observer_group_leader(pid()) -> kz_term:api_pid().
+get_observer_group_leader(Observer) ->
+    case process_info(Observer, 'group_leader') of
+        'undefined' -> 'undefined';
+        {'group_leader', GroupLeader} -> GroupLeader
+    end.
+
+%%------------------------------------------------------------------------------
+%% @doc Print the diagnostics output column headers to the console.
+%% @end
+%%------------------------------------------------------------------------------
+-spec print_header() -> 'ok'.
+print_header() ->
+    Format = create_format_of_length(?MESSAGE_LINE_LENGTH, "|  Timestamp  | ~-{{lineLength}}s |~n"),
+    io:format(Format, ["Message"]),
+    print_separator().
+
+%%------------------------------------------------------------------------------
+%% @doc Print a diagnostics output message row separator to the console.
+%% @end
+%%------------------------------------------------------------------------------
+-spec print_separator() -> 'ok'.
+print_separator() ->
+    Format = create_format_of_length(?MESSAGE_LINE_LENGTH, "|-------------|-~-{{lineLength}}s-|~n"),
+    io:format(Format
+             ,[lists:foldl(fun(_, Acc) -> "-" ++ Acc end, "", lists:seq(1, ?MESSAGE_LINE_LENGTH))]
+             ).
+
+%%------------------------------------------------------------------------------
+%% @doc Print the specified diagnostics message to the console.
+%% @end
+%%------------------------------------------------------------------------------
+-spec print(string()) -> 'ok'.
+print(Message) ->
+    print(Message, 'true').
+
+-spec print(string(), boolean()) -> 'ok'.
+print("", _) -> print_separator();
+print(Message, ShouldPrintTimestamp) ->
+    case ShouldPrintTimestamp of
+        'true' -> io:format("| ~b ", [kz_time:current_tstamp()]);
+        'false' -> io:format("|             ")
+    end,
+    {Part, Rest} = split_next_part(Message),
+    Format = create_format_of_length(?MESSAGE_LINE_LENGTH, "| ~-{{lineLength}}s |~n"),
+    io:format(Format, [Part]),
+    print(Rest, 'false').
+
+%%------------------------------------------------------------------------------
+%% @doc Split the diagnostics message into a chunk that can fit on the current
+%% line of the console and the rest of the message.
+%% @end
+%%------------------------------------------------------------------------------
+-spec split_next_part(string()) -> {string(), string()}.
+split_next_part(Message) ->
+    split_next_part(Message, "", 'false', ?MESSAGE_LINE_LENGTH).
+
+-spec split_next_part(string(), string(), boolean(), non_neg_integer()) -> {string(), string()}.
+split_next_part("", Part, _, _) -> {Part, ""};
+split_next_part(Rest, Part, 'true', 0) -> {Part, Rest};
+split_next_part(Rest, _, 'false', 0) ->
+    %% Blank line, ignore
+    split_next_part(Rest);
+split_next_part([$\n|Rest], Part, _, _) -> {Part, Rest};
+split_next_part([Ch|Rest], Part, IsNotBlankLine, RemainingCharCount) ->
+    IsNotBlankLine1 = IsNotBlankLine
+        orelse Ch =/= 32,
+    split_next_part(Rest, [Part, Ch], IsNotBlankLine1, RemainingCharCount - 1).
+
+%%------------------------------------------------------------------------------
+%% @doc Replace `{{lineLength}}' placeholders in a format string with the
+%% defined diagnostics log line length.
+%% @end
+%%------------------------------------------------------------------------------
+-spec create_format_of_length(pos_integer(), string()) -> string().
+create_format_of_length(Length, Format) ->
+    re:replace(Format, "{{lineLength}}", kz_term:to_binary(Length), [{'return', 'list'}]).

--- a/src/acdc_queue_manager_diag_sup.erl
+++ b/src/acdc_queue_manager_diag_sup.erl
@@ -1,0 +1,81 @@
+%%%-----------------------------------------------------------------------------
+%%% @copyright (C) 2021-, Ooma Inc.
+%%% @doc Supervises queue manager diagnostics receivers.
+%%% @author Daniel Finke
+%%% @end
+%%%-----------------------------------------------------------------------------
+-module(acdc_queue_manager_diag_sup).
+-behaviour(supervisor).
+
+-include("acdc.hrl").
+
+-define(SERVER, ?MODULE).
+
+%% API
+-export([start_link/0
+        ,start_diagnostics/2
+        ,send_diagnostics/2
+        ]).
+
+%% Supervisor callbacks
+-export([init/1]).
+
+-define(CHILDREN, [?WORKER_TYPE('acdc_queue_manager_diag', 'transient')]).
+
+%%%=============================================================================
+%%% api functions
+%%%=============================================================================
+
+%%------------------------------------------------------------------------------
+%% @doc Starts the supervisor.
+%% @end
+%%------------------------------------------------------------------------------
+-spec start_link() -> kz_types:startlink_ret().
+start_link() ->
+    supervisor:start_link({'local', ?SERVER}, ?MODULE, []).
+
+%%------------------------------------------------------------------------------
+%% @doc Start queue diagnostics for the specified queue.
+%% @end
+%%------------------------------------------------------------------------------
+-spec start_diagnostics(kz_term:ne_binary(), kz_term:ne_binary()) -> kz_types:sup_startchild_ret().
+start_diagnostics(AccountId, QueueId) ->
+    supervisor:start_child(?SERVER, [AccountId, QueueId, self()]).
+
+%%------------------------------------------------------------------------------
+%% @doc Send a diagnostics message to all the queue diagnostics receivers
+%% specified by `DiagSrvs'.
+%% @end
+%%------------------------------------------------------------------------------
+-spec send_diagnostics([pid()], iolist()) -> 'ok'.
+send_diagnostics(DiagSrvs, Message) ->
+    lists:foreach(fun(DiagSrv) ->
+                          acdc_queue_manager_diag:send_diagnostics(DiagSrv, Message)
+                  end
+                 ,DiagSrvs
+                 ).
+
+%%%=============================================================================
+%%% Supervisor callbacks
+%%%=============================================================================
+
+%%------------------------------------------------------------------------------
+%% @doc Whenever a supervisor is started using `supervisor:start_link/[2,3]',
+%% this function is called by the new process to find out about
+%% restart strategy, maximum restart frequency and child
+%% specifications.
+%% @end
+%%------------------------------------------------------------------------------
+-spec init([]) -> kz_types:sup_init_ret().
+init([]) ->
+    RestartStrategy = 'simple_one_for_one',
+    MaxRestarts = 3,
+    MaxSecondsBetweenRestarts = 5,
+
+    SupFlags = {RestartStrategy, MaxRestarts, MaxSecondsBetweenRestarts},
+
+    {'ok', {SupFlags, ?CHILDREN}}.
+
+%%%=============================================================================
+%%% Internal functions
+%%%=============================================================================

--- a/src/acdc_queue_sup.erl
+++ b/src/acdc_queue_sup.erl
@@ -67,7 +67,7 @@ status(Supervisor) ->
     ?PRINT("  Manager: ~p", [Manager]),
 
     ?PRINT("    Known Agents:"),
-    _ = case acdc_queue_manager:status(Manager) of
+    _ = case acdc_queue_manager:agents(Manager) of
             [] -> ?PRINT("      NONE");
             As -> [?PRINT("      ~s", [A]) || A <- As]
         end,

--- a/src/acdc_sup.erl
+++ b/src/acdc_sup.erl
@@ -30,6 +30,7 @@
                   ,?SUPER('acdc_queues_sup')
                   ,?SUPER('acdc_stats_sup')
                   ,?SUPER('acdc_announcements_sup')
+                  ,?SUPER('acdc_queue_manager_diag_sup')
                   ,?WORKER('acdc_agent_manager')
                   ,?WORKER('acdc_init')
                   ,?WORKER('acdc_listener')
@@ -57,7 +58,7 @@ start_link() ->
 %%------------------------------------------------------------------------------
 -spec init(any()) -> kz_types:sup_init_ret().
 init([]) ->
-    kz_process:set_startup(),
+    _ = kz_process:set_startup(),
     RestartStrategy = 'one_for_one',
     MaxRestarts = 5,
     MaxSecondsBetweenRestarts = 10,

--- a/src/acdc_util.erl
+++ b/src/acdc_util.erl
@@ -25,6 +25,7 @@
         ,caller_id/1
         ,hangup_cause/1
         ,max_priority/2
+        ,queue_remove/2
         ]).
 
 -include("acdc.hrl").
@@ -173,3 +174,14 @@ max_priority(AccountDb, QueueId) ->
 -spec max_priority(kz_json:object()) -> kz_term:api_integer().
 max_priority(QueueJObj) ->
     kz_json:get_integer_value(<<"max_priority">>, QueueJObj).
+
+%%------------------------------------------------------------------------------
+%% @doc Remove `Term' from `Queue', returning a tuple where the 1st element is
+%% true if `Term' was found and removed and the 2nd element is the updated
+%% queue.
+%% @end
+%%------------------------------------------------------------------------------
+-spec queue_remove(any(), queue:queue()) -> {boolean(), queue:queue()}.
+queue_remove(Term, Queue) ->
+    Queue1 = queue:filter(fun(Elem) -> Elem =/= Term end, Queue),
+    {Queue1 =/= Queue, Queue1}.

--- a/test/acdc_queue_manager_tests.erl
+++ b/test/acdc_queue_manager_tests.erl
@@ -23,17 +23,29 @@
 %%% =====
 
 %%------------------------------------------------------------------------------
-%% @doc
+%% @doc Test the reported count of agents when the "most idle" strategy state is
+%% empty.
 %% @end
 %%------------------------------------------------------------------------------
-ss_size_empty_test_() ->
-    SS = #strategy_state{agents=[]},
-    [?_assertEqual(0, acdc_queue_manager:ss_size(SS, 'free'))
-    ,?_assertEqual(0, acdc_queue_manager:ss_size(SS, 'logged_in'))].
+agent_count_0_agents_test_() ->
+    State = #state{strategy='mi'
+                  ,strategy_state=#strategy_state{agents=[]}
+                  },
+    [?_assertEqual(0, acdc_queue_manager:assignable_agent_count(State))
+    ,?_assertEqual(0, acdc_queue_manager:agent_count(State))].
 
-ss_size_one_busy_test_() ->
-    SS = #strategy_state{agents=[]},
-    SS1 = acdc_queue_manager:update_strategy_with_agent('mi', SS, ?AGENT_ID, 'add', 'undefined'),
-    SS2 = acdc_queue_manager:update_strategy_with_agent('mi', SS1, ?AGENT_ID, 'remove', 'busy'),
-    [?_assertEqual(0, acdc_queue_manager:ss_size(SS2, 'free'))
-    ,?_assertEqual(1, acdc_queue_manager:ss_size(SS2, 'logged_in'))].
+%%------------------------------------------------------------------------------
+%% @doc Test the reported count of agents when the "most idle" strategy state
+%% has an agent added and then flagged as busy.
+%% @end
+%%------------------------------------------------------------------------------
+agent_count_1_busy_agent_test_() ->
+    State = #state{strategy='mi'
+                  ,strategy_state=#strategy_state{agents=[]}
+                  },
+    SS1 = acdc_queue_manager:update_strategy_with_agent(State, ?AGENT_ID, 'available'),
+    State1 = State#state{strategy_state=SS1},
+    SS2 = acdc_queue_manager:update_strategy_with_agent(State1, ?AGENT_ID, 'busy'),
+    State2 = State1#state{strategy_state=SS2},
+    [?_assertEqual(0, acdc_queue_manager:assignable_agent_count(State2))
+    ,?_assertEqual(1, acdc_queue_manager:agent_count(State2))].


### PR DESCRIPTION
- rename some queue manager funs and call/cast messages for clarity
- refactor agent ID list and count funs
  - replace ss_size
- big refactor of update_strategy_with_agent
- diagnostics launcher funs
- diagnostics receiver attachment to queue manager
- ?DIAG macro and payload transformation
- create acdc_queue_manager_diag_sup
- update unit tests